### PR TITLE
fix(security): suppress false-positive B701 in load_prompt

### DIFF
--- a/src/otter/dataset/utils.py
+++ b/src/otter/dataset/utils.py
@@ -135,10 +135,12 @@ def load_prompt(
     template_path = Path(template_path)
     if not template_path.is_file():
         raise FileNotFoundError(f"File not found: {template_path}")
+    # autoescape=False is intentional: templates are used as LLM prompts (not HTML),
+    # so escaping < > & would corrupt the prompt content.
     env = Environment(
         loader=FileSystemLoader(str(template_path.parent)),
-        undefined=StrictUndefined, 
-        autoescape=False,
+        undefined=StrictUndefined,
+        autoescape=False,  # nosec B701
         keep_trailing_newline=True,
     )
     template = env.get_template(template_path.name)


### PR DESCRIPTION
## Summary

Bandit flags `autoescape=False` in `load_prompt()` as HIGH severity (B701). This is a **false positive**:

- Templates (`sweci_prompt.jinja2`) contain XML-like tags used as **LLM prompts**, not HTML
- Enabling autoescape would corrupt the prompt content by escaping `<`, `>`, `&`
- Template variables (e.g. `role`) are hardcoded strings, not user input

## Changes

- Add explanatory comment for why `autoescape=False` is intentional
- Add `# nosec B701` to suppress the bandit warning
- Remove trailing space after `StrictUndefined,`

## Files

- `src/otter/dataset/utils.py`