### PR TITLE
docs: fix docker backend default values in env_config

### DIFF
--- a/docs/en/env_config.md
+++ b/docs/en/env_config.md
@@ -97,9 +97,9 @@ All `str | None` fields above accept an empty value to set `None` (removing the 
 ```env
 EVALUATOR_TYPE=docker
 EVALUATOR__cpus=1.0
-EVALUATOR__memory=512m
+EVALUATOR__memory=4096m
 EVALUATOR__timeout=10
-EVALUATOR__network_mode=none
+EVALUATOR__network_mode=host
 ```
 
 ---
@@ -163,10 +163,10 @@ EXECUTOR__retry_base_delay=1.0
 
 # ── Evaluator (docker) ──
 EVALUATOR__cpus=1.0
-EVALUATOR__memory=512m
-EVALUATOR__memory_swap=512m
-EVALUATOR__memory_reservation=256m
-EVALUATOR__network_mode=none
+EVALUATOR__memory=4096m
+EVALUATOR__memory_swap=4096m
+EVALUATOR__memory_reservation=2048m
+EVALUATOR__network_mode=host
 EVALUATOR__device_read_bps=128m
 EVALUATOR__device_write_bps=128m
 EVALUATOR__timeout=10

--- a/docs/zh/env_config.md
+++ b/docs/zh/env_config.md
@@ -97,9 +97,9 @@ EXECUTOR__retry_base_delay=1.0
 ```env
 EVALUATOR_TYPE=docker
 EVALUATOR__cpus=1.0
-EVALUATOR__memory=512m
+EVALUATOR__memory=4096m
 EVALUATOR__timeout=10
-EVALUATOR__network_mode=none
+EVALUATOR__network_mode=host
 ```
 
 ---
@@ -163,10 +163,10 @@ EXECUTOR__retry_base_delay=1.0
 
 # ── Evaluator (docker) ──
 EVALUATOR__cpus=1.0
-EVALUATOR__memory=512m
-EVALUATOR__memory_swap=512m
-EVALUATOR__memory_reservation=256m
-EVALUATOR__network_mode=none
+EVALUATOR__memory=4096m
+EVALUATOR__memory_swap=4096m
+EVALUATOR__memory_reservation=2048m
+EVALUATOR__network_mode=host
 EVALUATOR__device_read_bps=128m
 EVALUATOR__device_write_bps=128m
 EVALUATOR__timeout=10


### PR DESCRIPTION
## Summary

Default values for Docker backend parameters in the documentation did not match the actual code defaults in `backend_settings.py`.

## Corrections

| Parameter | Doc (wrong) | Code (correct) |
|-----------|-------------|----------------|
| `memory` | `512m` | `4096m` |
| `memory_swap` | `512m` | `4096m` |
| `memory_reservation` | `256m` | `2048m` |
| `network_mode` | `none` | `host` |

Both the parameter table and the example `.env` block have been updated in English and Chinese docs.

## Files

- `docs/en/env_config.md`
- `docs/zh/env_config.md`