### PR TITLE
docs: add SWE-CI dataset parameter documentation

### DIFF
--- a/docs/en/env_config.md
+++ b/docs/en/env_config.md
@@ -120,6 +120,17 @@ Dataset parameters use the `DATASET__` prefix. The available fields depend on th
 |---------|------|---------|---------|-------------|
 | `DATASET__cache_dir` | Path | `data/cache` | untracked | Local cache directory for HuggingFace datasets |
 
+### sweci (SWE-CI)
+
+| Variable | Type | Default | Tracked | Description |
+|---------|------|---------|---------|-------------|
+| `DATASET__splitting` | str | `"default"` | tracked | Dataset splitting to use (e.g., `default`, `mini`) |
+| `DATASET__agent_name` | str | `"opencode"` | tracked | AI CLI agent to use (`claude`, `codex`, `opencode`, `openhands`) |
+| `DATASET__agent_api_key` | str | `""` | untracked | API key for the AI CLI agent |
+| `DATASET__agent_model_name` | str | `""` | tracked | Model name for the AI CLI agent |
+| `DATASET__agent_base_url` | str | `""` | tracked | Base URL for the AI CLI agent API |
+| `DATASET__cache_dir` | Path | `data/cache` | untracked | Local cache directory for HuggingFace datasets |
+
 ---
 
 ## Logger Parameters

--- a/docs/zh/env_config.md
+++ b/docs/zh/env_config.md
@@ -120,6 +120,17 @@ EVALUATOR__network_mode=none
 |---------|------|--------|---------|------|
 | `DATASET__cache_dir` | Path | `data/cache` | untracked | HuggingFace 数据集的本地缓存目录 |
 
+### sweci（SWE-CI）
+
+| 环境变量 | 类型 | 默认值 | tracked | 说明 |
+|---------|------|--------|---------|------|
+| `DATASET__splitting` | str | `"default"` | tracked | 使用的数据集划分（如 `default`、`mini`） |
+| `DATASET__agent_name` | str | `"opencode"` | tracked | AI CLI 智能体（`claude`、`codex`、`opencode`、`openhands`） |
+| `DATASET__agent_api_key` | str | `""` | untracked | AI CLI 智能体的 API Key |
+| `DATASET__agent_model_name` | str | `""` | tracked | AI CLI 智能体使用的模型名称 |
+| `DATASET__agent_base_url` | str | `""` | tracked | AI CLI 智能体的 API 基础 URL |
+| `DATASET__cache_dir` | Path | `data/cache` | untracked | HuggingFace 数据集的本地缓存目录 |
+
 ---
 
 ## 日志参数


### PR DESCRIPTION
## Summary

The SWE-CI (`sweci`) dataset has several configuration parameters that were missing from the documentation.

## Added Parameters

| Variable | Type | Default | Tracked | Description |
|---------|------|---------|---------|-------------|
| `DATASET__splitting` | str | `"default"` | tracked | Dataset splitting to use |
| `DATASET__agent_name` | str | `"opencode"` | tracked | AI CLI agent (`claude`, `codex`, `opencode`, `openhands`) |
| `DATASET__agent_api_key` | str | `""` | untracked | API key for the AI CLI agent |
| `DATASET__agent_model_name` | str | `""` | tracked | Model name for the AI CLI agent |
| `DATASET__agent_base_url` | str | `""` | tracked | Base URL for the AI CLI agent API |
| `DATASET__cache_dir` | Path | `data/cache` | untracked | Local cache directory |

## Files

- `docs/en/env_config.md`
- `docs/zh/env_config.md`