### PR TITLE
style: fix E701 multi-statement lines and F541 empty f-string

### DIFF
--- a/src/otter/dataset/sweci.py
+++ b/src/otter/dataset/sweci.py
@@ -65,7 +65,7 @@ def generate_nonpassed_dir(
             else:
                 f.write(json.dumps({
                     'test': node_id,
-                    'description': f"This test was not properly collected or executed in the current run, so no detailed traceback is available. However, it was recorded as 'passed' in the target report."
+                    'description': "This test was not properly collected or executed in the current run, so no detailed traceback is available. However, it was recorded as 'passed' in the target report."
                 }, ensure_ascii=False) + '\n')
     return len(nonpassed_ids)
 

--- a/src/otter/pipeline.py
+++ b/src/otter/pipeline.py
@@ -17,9 +17,12 @@ def create_dataset() -> dataset.BaseDataset:
     settings = get_settings()
     output_dir = settings.output_dir
     match settings.dataset_name:
-        case "evalplus": return dataset.EvalPlusDataset(output_dir)
-        case "mbppplus": return dataset.MBPPPlusDataset(output_dir)
-        case "sweci": return dataset.SWECIDataset(output_dir)
+        case "evalplus":
+            return dataset.EvalPlusDataset(output_dir)
+        case "mbppplus":
+            return dataset.MBPPPlusDataset(output_dir)
+        case "sweci":
+            return dataset.SWECIDataset(output_dir)
         case _:
             raise ValueError(f"unknown dataset: {settings.dataset_name}")
 


### PR DESCRIPTION
- `pipeline.py`: split match/case single-line returns into multi-line
- `sweci.py`: remove extraneous f-prefix from static string