### PR TITLE
refactor: replace star imports with explicit imports in setting.py

### DIFF
--- a/src/otter/config/setting.py
+++ b/src/otter/config/setting.py
@@ -3,8 +3,12 @@ from typing import Literal, Any
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from .backend_settings import *
-from .dataset_settings import *
+from .backend_settings import (
+    BackendSettings, BACKEND_SETTINGS_REGISTRY,
+)
+from .dataset_settings import (
+    DatasetSettings, DATASET_SETTINGS_REGISTRY,
+)
 from .utils import (
     ROOT_DIR, tracked_field, untracked_field, coerce_empty_str
     ) 


### PR DESCRIPTION
Replace `from .backend_settings import *` and `from .dataset_settings import *` with explicit imports of only the symbols actually used:
- `BackendSettings`, `BACKEND_SETTINGS_REGISTRY`
- `DatasetSettings`, `DATASET_SETTINGS_REGISTRY`

Eliminates F403/F405 warnings from ruff.