### PR TITLE
refactor: clean up unused imports and variables in tests/

### DIFF
--- a/tests/backend/test_chat_llm.py
+++ b/tests/backend/test_chat_llm.py
@@ -1,7 +1,5 @@
 """Tests for otter.backend.chat_llm module."""
 
-import pytest
-from pathlib import Path
 
 from otter.backend.chat_llm import ChatLLMBackend
 

--- a/tests/backend/test_docker.py
+++ b/tests/backend/test_docker.py
@@ -2,7 +2,6 @@
 
 import asyncio
 
-import pytest
 from pathlib import Path
 from dataclasses import dataclass
 

--- a/tests/backend/utils/test_docker_utils.py
+++ b/tests/backend/utils/test_docker_utils.py
@@ -9,7 +9,6 @@ Tests verify:
 
 import pytest
 import asyncio
-from unittest.mock import MagicMock, patch
 from subprocess import CompletedProcess
 
 from otter.backend.utils import docker_utils as mod

--- a/tests/backend/utils/test_sync_docker_utils.py
+++ b/tests/backend/utils/test_sync_docker_utils.py
@@ -7,8 +7,8 @@ import pytest
 import docker
 import tarfile
 import subprocess
-from pathlib import Path, PurePosixPath
-from unittest.mock import MagicMock, patch, call
+from pathlib import PurePosixPath
+from unittest.mock import MagicMock
 
 import otter.backend.utils.sync_docker_utils as mod
 
@@ -142,8 +142,6 @@ class TestGetDockerStorageDevice:
     def test_falls_back_to_root_when_docker_root_missing(self, mocker):
         mocker.patch("otter.backend.utils.sync_docker_utils.platform.system", return_value="Linux")
         # docker info returns a non-existent path
-        call_count = [0]
-        original_exists = Path.exists
 
         def mock_check_output(cmd, **kwargs):
             if "docker" in cmd:

--- a/tests/config/test_dataset_settings.py
+++ b/tests/config/test_dataset_settings.py
@@ -1,6 +1,5 @@
 """Tests for otter.config.dataset_settings module."""
 
-import pytest
 from pathlib import Path
 
 from otter.config.dataset_settings import (

--- a/tests/config/test_setting.py
+++ b/tests/config/test_setting.py
@@ -12,7 +12,6 @@ from otter.config.setting import (
     init_settings,
     get_settings,
     get_tracked_config,
-    _settings,
 )
 from otter.config.backend_settings import ChatLLMSettings, DockerSettings
 from otter.config.dataset_settings import MbppplusSettings, EvalplusSettings

--- a/tests/config/test_utils.py
+++ b/tests/config/test_utils.py
@@ -1,6 +1,5 @@
 """Tests for otter.config.utils module."""
 
-import pytest
 from pydantic_core import PydanticUndefined
 
 from otter.config.utils import (

--- a/tests/dataset/test_base.py
+++ b/tests/dataset/test_base.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from otter.dataset.base import BaseDataset
-from otter.episode import Episode, InputManifest, OutputManifest, Turn, META_FILENAME
+from otter.episode import Episode, InputManifest, Turn, META_FILENAME
 
 
 class ConcreteDataset(BaseDataset):

--- a/tests/dataset/test_evalplus.py
+++ b/tests/dataset/test_evalplus.py
@@ -1,10 +1,9 @@
 """Tests for otter.dataset.evalplus module."""
 
 import pytest
-from pathlib import Path
 
 from otter.dataset.evalplus import EvalPlusDataset, HumanEvalProblem
-from otter.episode import Episode, Turn, InputManifest, OutputManifest
+from otter.episode import Episode, Turn, OutputManifest
 
 
 class TestHumanEvalProblem:

--- a/tests/dataset/test_mbppplus.py
+++ b/tests/dataset/test_mbppplus.py
@@ -1,10 +1,9 @@
 """Tests for otter.dataset.mbppplus module."""
 
 import pytest
-from pathlib import Path
 
 from otter.dataset.mbppplus import MBPPPlusDataset, MBPPPlusProblem
-from otter.episode import Episode, Turn, InputManifest, OutputManifest
+from otter.episode import Episode, Turn, OutputManifest
 
 
 class TestMBPPPlusProblem:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 """Tests for otter.cli module."""
 
-from pathlib import Path
 
 import pytest
 import typer
@@ -65,7 +64,7 @@ class TestRunCommand:
 
         mock_init_settings = mocker.patch("otter.config.setting.init_settings")
         mock_init_logger = mocker.patch("otter.logger.init_logger")
-        mock_main = mocker.patch("otter.pipeline.main")
+        mocker.patch("otter.pipeline.main")
         mock_asyncio_run = mocker.patch("otter.cli.asyncio.run")
 
         result = runner.invoke(app, ["run", "--env", str(env_file)])

--- a/tests/test_episode.py
+++ b/tests/test_episode.py
@@ -3,11 +3,9 @@
 import json
 from pathlib import Path
 
-import pytest
 
 from otter.episode import (
     _is_path_field,
-    BaseManifest,
     InputManifest,
     OutputManifest,
     Turn,

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,10 +1,8 @@
 """Tests for otter.logger module."""
 
 import logging
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 
 class TestGetLogger:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,7 +2,6 @@
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import pytest
 
 from otter.episode import Episode, InputManifest, OutputManifest, Turn
 from otter.role import (
@@ -12,7 +11,6 @@ from otter.role import (
     pack_docker,
     EXTRACT_DISPATCH,
     PACK_DISPATCH,
-    BaseRole,
     ProposerRole,
     ExecutorRole,
     EvaluatorRole,

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,7 +1,6 @@
 """Tests for otter.summary module."""
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -10,7 +9,6 @@ from otter.summary import (
     TurnStats,
     SampleSummary,
     ExperimentSummary,
-    _load_episodes,
     _compute_turn_stats,
     summarize,
     show_summary,


### PR DESCRIPTION
Remove unused imports (`pytest`, `Path`, `MagicMock`, `patch`, `AsyncMock`, `BaseRole`, `_load_episodes`, etc.) and unused local variables (`call_count`, `original_exists`, `mock_main`) across 16 test files.

All ruff F401/F841 checks now pass for `tests/`.